### PR TITLE
Add components as optional param for autocomplete

### DIFF
--- a/src/GoogleConstants.js
+++ b/src/GoogleConstants.js
@@ -23,7 +23,7 @@ export const API = {
   AUTOCOMPLETE: {
     path: 'autocomplete',
     requiredKeys: ['input'],
-    optionalKeys: ['offset', 'location', 'radius', 'languages', 'types', 'strictbounds']
+    optionalKeys: ['offset', 'location', 'radius', 'languages', 'types', 'strictbounds', 'components']
   }
 };
 


### PR DESCRIPTION
Add components as optional param for autocomplete. This allows restricting results to a country or up to 5 countries.
Format: country:au|country:fr|country:us 
https://developers.google.com/places/web-service/autocomplete