### PR TITLE
Add: region to supported textsearch parameters

### DIFF
--- a/src/google/Constants.ts
+++ b/src/google/Constants.ts
@@ -110,7 +110,8 @@ export const API: ApiMap = {
       'opennow',
       'radius',
       'type',
-      'pagetoken'
+      'pagetoken',
+      'region'
     ],
     path: 'textsearch',
     requiredKeys: ['query']

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,7 @@ export interface GooglePlacesTextSearchOpts extends GooglePlacesOptions {
   query: string;
   radius?: number;
   type?: string;
+  region?: string;
 }
 
 interface BaseGoogleResult {


### PR DESCRIPTION
[This parameter](https://developers.google.com/maps/documentation/places/web-service/search-text?_gl=1*1gvsxo1*_up*MQ..*_ga*NjQ0MjI5MzM1LjE3MjA0MTg2MjA.*_ga_NRWSTWS78N*MTcyMDQxODYxOS4xLjAuMTcyMDQxODYxOS4wLjAuMA..#region) was not supported.